### PR TITLE
fix: ensure deploy workflow triggers on push to main

### DIFF
--- a/.github/workflows/deploy-linode.yml
+++ b/.github/workflows/deploy-linode.yml
@@ -35,9 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     # Skip deployment if triggered by semantic-release commit (contains [skip ci])
     # Always deploy when triggered by workflow_run (after release completes)
+    # Deploy on push to main unless commit contains [skip ci]
     if: |
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' && !contains(github.event.head_commit.message, '[skip ci]')) ||
+      (github.event_name == 'push' && github.event.head_commit.message != null && !contains(github.event.head_commit.message, '[skip ci]')) ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     environment: ${{ github.event.inputs.environment || 'production' }}
     steps:


### PR DESCRIPTION
## Problem

The deploy workflow didn't trigger after merging PR #29 to main, even though the commit didn't contain `[skip ci]`.

## Solution

Added a null check for `github.event.head_commit.message` to ensure the workflow doesn't get skipped when the commit message is null or undefined.

## Testing

This should ensure deployments trigger properly on all pushes to main (except those with `[skip ci]`).