### PR TITLE
fix: inject version at build time for Next.js

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,9 +1,19 @@
 // Injected content via Sentry wizard below
 import { withSentryConfig } from "@sentry/nextjs";
 
+// Read version from package.json for build-time injection
+import { readFileSync } from 'fs';
+const packageJson = JSON.parse(readFileSync('./package.json', 'utf8'));
+const appVersion = packageJson.version || 'unknown';
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
+  // Inject version as environment variable at build time
+  env: {
+    NEXT_PUBLIC_VERSION: appVersion,
+    VERSION: appVersion,
+  },
   // Suppress webpack cache warnings
   webpack: (config, { dev }) => {
     if (dev) {


### PR DESCRIPTION
## Problem

The version wasn't available in the Next.js application when deployed via PM2. Next.js requires `NEXT_PUBLIC_` environment variables to be available at build time, not just runtime.

## Solution

Updated `next.config.mjs` to:
- Read version from `package.json` at build time
- Inject it as `NEXT_PUBLIC_VERSION` and `VERSION` environment variables
- This ensures the version is available in both client and server code

## How It Works

1. During `bun run build`, `next.config.mjs` reads the version from `package.json`
2. The version is injected as environment variables that Next.js can access
3. PM2 also sets the version at runtime (for server-side access)
4. Both build-time and runtime versions will match

## Testing

After merging and deploying, the version should be accessible via:
- `process.env.NEXT_PUBLIC_VERSION` (client-side)
- `process.env.VERSION` (server-side)