### PR TITLE
feat: enable PM2 version metadata

### DIFF
--- a/ecosystem.prod.config.js
+++ b/ecosystem.prod.config.js
@@ -45,7 +45,8 @@ module.exports = {
         NEXT_PUBLIC_VERSION: appVersion,
         // These will be merged from shell environment when using --update-env
         // Do not set defaults here - they must be provided by the deployment script
-      }
+      },
+      version_metadata: true
     }
   ]
 };


### PR DESCRIPTION
## Changes

Enable PM2 version metadata tracking by adding `version_metadata: true` to the ecosystem configuration.

## Benefits

- PM2 will track and display version information in monitoring tools
- Version metadata will be available via PM2 API and CLI commands
- Helps with debugging and monitoring which version is running

## Testing

After merging and deploying, version metadata will be available via:
- `pm2 describe nightscout-backup-site`
- PM2 monitoring dashboards
- PM2 API endpoints