### PR TITLE
feat: add SonarQube issues sync workflow

### DIFF
--- a/.github/workflows/sonarqube-issues-to-github.yml
+++ b/.github/workflows/sonarqube-issues-to-github.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Fetch SonarQube issues
         run: |
           curl -s -u "${{ secrets.SONAR_TOKEN }}:" \
-            "https://sonarcloud.io/api/issues/search?componentKeys=dustin-lennon_NightScoutMongoBackup&resolved=false" \
+            "https://sonarcloud.io/api/issues/search?componentKeys=stelth2000-inc_NightScoutMongoBackupSite&resolved=false" \
             -o sonar-issues.json
 
       - name: Create GitHub issues


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that syncs SonarQube issues to GitHub Issues.

## Changes
- Added  workflow
- Workflow runs every 15 minutes via cron schedule
- Can also be manually triggered via workflow_dispatch
- Fetches unresolved issues from SonarQube and creates corresponding GitHub issues
- Limits to first 5 issues per run to prevent spam

## Configuration Required
-  secret needs to be configured in repository settings
- Update the SonarQube URL placeholder in the workflow file