### PR TITLE
chore: add next-env.d.ts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ logs
 
 .env.keys
 NGINX_DEPLOYMENT.md
+next-env.d.ts

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
This PR adds  to  and removes it from git tracking. This file is auto-generated by Next.js and should not be tracked in version control to avoid unnecessary commits and merge conflicts.