### PR TITLE
feat: Add Codecov coverage upload to TypeScript testing workflow

### DIFF
--- a/.github/workflows/typescript-testing.yml
+++ b/.github/workflows/typescript-testing.yml
@@ -37,6 +37,15 @@ jobs:
           path: coverage/
           retention-days: 7
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        if: always()
+        with:
+          file: ./coverage/lcov.info
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+
   e2e-tests:
     name: Run E2E Tests
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
This PR adds Codecov coverage upload to the TypeScript testing workflow, matching the implementation in NightScoutMongoBackup.

## Changes
- Added Codecov upload step to `.github/workflows/typescript-testing.yml`
- Coverage reports will now be uploaded to Codecov for badges and PR comments
- Maintains existing artifact upload and SonarCloud integration

## Testing
- All existing tests pass
- Coverage configuration already in place via vitest.config.mts
- LCOV reports are generated and will be uploaded to Codecov

## Related
- Implements code coverage similar to NightScoutMongoBackup project
- Closes #54