### PR TITLE
fix: resolve workflow warnings

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: CodeQL Analysis
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/typescript-testing.yml
+++ b/.github/workflows/typescript-testing.yml
@@ -46,7 +46,7 @@ jobs:
         uses: codecov/codecov-action@v5
         if: always()
         with:
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false


### PR DESCRIPTION
This PR fixes two workflow warnings:

- **CodeQL Analysis**: Added `on.push` hook to enable code scanning alerts on the Security tab for the default branch
- **TypeScript Testing**: Fixed Codecov action input parameter from `file` to `files` (plural) as required by codecov-action@v5

Both workflows should now run without warnings.